### PR TITLE
data count and transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carabao-mongo",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Reusable MongoDB utilities and query logic",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/model/collection.ts
+++ b/src/model/collection.ts
@@ -1,3 +1,4 @@
+import { PaginatedResult } from "./paginated.result"
 import { Query, WherePredicate } from "./query"
 
 /**
@@ -47,5 +48,5 @@ export interface Collection<T> {
    * @param query - The query specifying the records to find.
    * @returns A promise that resolves to an array of matching records.
    */
-  findMultipleData: (query?: Query<T>) => Promise<T[]>
+  findMultipleData: (query?: Query<T>) => Promise<PaginatedResult<T>>
 }

--- a/src/model/collection.ts
+++ b/src/model/collection.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb"
 import { PaginatedResult } from "./paginated.result"
 import { Query, WherePredicate } from "./query"
 
@@ -12,14 +13,14 @@ export interface Collection<T> {
    * @param uniqueFields - Optional array of field names to enforce uniqueness.
    * @returns A promise that resolves to the unique ID of the inserted record.
    */
-  insertData: (data: T, uniqueFields?: (keyof T)[]) => Promise<string>
+  insertData: (data: T, uniqueFields?: (keyof T)[], session?: MongoClient['startSession']) => Promise<string>
 
   /**
    * Inserts multiple records into the collection.
    * @param datas - An array of data objects to insert.
    * @returns A promise that resolves to an array of unique IDs of the inserted records.
    */
-  insertMultipleData: (datas: T[]) => Promise<string[]>
+  insertMultipleData: (datas: T[], session?: MongoClient['startSession']) => Promise<string[]>
 
   /**
    * Updates records matching the given query.
@@ -27,14 +28,14 @@ export interface Collection<T> {
    * @param data - The updated data to apply.
    * @returns A promise that resolves to the number of datas updated when the update is complete.
    */
-  updateData: (query: WherePredicate<T>, data: Partial<T>) => Promise<number>
+  updateData: (query: WherePredicate<T>, data: Partial<T>, session?: MongoClient['startSession']) => Promise<number>
 
   /**
- * Deletes all records matching the given query.
- * @param query - The filter query specifying which records to delete.
- * @returns A promise that resolves to the number of deleted documents.
- */
-  deleteData: (query: WherePredicate<T>) => Promise<number>
+   * Deletes all records matching the given query.
+   * @param query - The filter query specifying which records to delete.
+   * @returns A promise that resolves to the number of deleted documents.
+   */
+  deleteData: (query: WherePredicate<T>, session?: MongoClient['startSession']) => Promise<number>
 
   /**
    * Finds the first record that matches the given query.
@@ -49,4 +50,12 @@ export interface Collection<T> {
    * @returns A promise that resolves to an array of matching records.
    */
   findMultipleData: (query?: Query<T>) => Promise<PaginatedResult<T>>
+
+  /**
+   * Executes a series of operations within a transaction.
+   * @param operations - A callback function containing the operations to execute.
+   * @returns The result of the transaction, if successful.
+   * @throws An error if the transaction fails.
+   */
+  executeTransaction: <T>(operations: (session: MongoClient['startSession']) => Promise<T>) => Promise<T>
 }

--- a/src/model/paginated.result.ts
+++ b/src/model/paginated.result.ts
@@ -1,0 +1,4 @@
+export interface PaginatedResult<T> {
+  datas: T[]
+  totalCount: number
+}


### PR DESCRIPTION
- return the total numbers of matching data when getting datas regardless of the pagination
- allow users to use transactions to rollback failed queries
- update version to 0.2.0