### PR TITLE
Move transactions and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ const userCollection = await getCollection<User>('users')
 ### Insert Data
 
 #### Insert a Single Document
+
 ```typescript
 const userId = await userCollection.insertData({
   name: 'John Doe',
@@ -79,6 +80,7 @@ console.log('Inserted User ID:', userId)
 ```
 
 #### Insert Multiple Documents
+
 ```typescript
 const userIds = await userCollection.insertMultipleData([
   { name: 'Alice', email: 'alice@example.com', createdAt: new Date(), status: 'active' },
@@ -92,6 +94,7 @@ console.log('Inserted User IDs:', userIds)
 ### Query Data
 
 #### Find a Single Document
+
 ```typescript
 const user = await userCollection.findSingleData({
   where: { email: 'john.doe@example.com' }
@@ -100,6 +103,7 @@ console.log('User:', user)
 ```
 
 #### Find Multiple Documents
+
 ```typescript
 const activeUsers = await userCollection.findMultipleData({
   where: { status: 'active' },
@@ -140,12 +144,25 @@ console.log('Deleted Documents:', deletedCount)
 #### Example: Join with Another Collection
 
 ```typescript
-const projects = await userCollection.findMultipleData({
+interface Project {
+  uuid?: string
+  name: string
+  createdBy: string // UUID of the user who created the project
+  members: string[] // UUIDs of users who are members of the project
+}
+
+const projectCollection = await getCollection<Project>('projects')
+
+const projects = await projectCollection.findMultipleData({
   join: {
-    createdBy: { collectionName: 'users', select: ['name', 'email'] }
+    createdBy: { collectionName: 'users', select: ['name', 'email'] },
+    members: { collectionName: 'users', select: ['name', 'email'] }
   },
   where: { status: 'active' }
 })
+
+// projects will now contain the joined data instead of just UUIDs
+
 console.log('Projects with User Info:', projects)
 ```
 
@@ -200,9 +217,9 @@ try {
 ## **Contributing**
 
 1. Clone the repository:
-   ```bash
+```bash
    git clone https://github.com/yourusername/carabao-mongo.git
-   ```
+```
 2. Install dependencies:
    ```bash
    npm install
@@ -216,7 +233,7 @@ try {
 
 ## **License**
 
-Carabao-Mongo is licensed under the MIT License. See the [LICENSE](./LICENSE) file for more details.
+Carabao-Mongo is licensed under the MIT License. See the [LICENSE](https://github.com/TinyRabarioelina/carabao-mongo/blob/main/LICENSE) file for more details.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carabao-mongo",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Reusable MongoDB utilities and query logic",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -21,10 +21,11 @@ export const connectDatabase = async (databaseUrl: string) => {
 }
 
 /**
- * Open the specified Database
+ * Return the original MongoDB database in order to permit raw queries.
+ * This ensures that users still have the choice to use MongoDB directly.
  * @returns the database
  */
-const getDatabase = async () => db
+const getRawDatabase = () => db
 
 /**
  * Close the current connection to the database
@@ -71,7 +72,7 @@ const convertUuidToId = (filter: Record<string, unknown>) => {
  * @returns an object allowing queries inside the given collection name
  */
 export const getCollection = async <T extends { uuid?: string | ObjectId }>(collectionName: string): Promise<Collection<T>> => {
-  const db = await getDatabase()
+  const db = getRawDatabase()
   const collection = db.collection(collectionName)
 
   const findData = async (query?: Query<T>, single?: boolean): Promise<PaginatedResult<T>> => {

--- a/src/model/collection.ts
+++ b/src/model/collection.ts
@@ -50,12 +50,4 @@ export interface Collection<T> {
    * @returns A promise that resolves to an array of matching records.
    */
   findMultipleData: (query?: Query<T>) => Promise<PaginatedResult<T>>
-
-  /**
-   * Executes a series of operations within a transaction.
-   * @param operations - A callback function containing the operations to execute.
-   * @returns The result of the transaction, if successful.
-   * @throws An error if the transaction fails.
-   */
-  executeTransaction: <T>(operations: (session: MongoClient['startSession']) => Promise<T>) => Promise<T>
 }


### PR DESCRIPTION
- move transactions logic out of collections in order to let users to combine multiple queries from different collections
- update misleading readme that used the wrong collection in the join part / add some more comments to explain how it works
- increment version to 0.2.1